### PR TITLE
Latest Brunch was building incorrectly - temp fix until resolved.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "form-data": "latest"
   },
   "devDependencies": {
-    "brunch": "latest",
+    "brunch": "1.7.20",
     "library-brunch": "latest",
     "javascript-brunch": "latest",
     "coffee-script-brunch": "latest",


### PR DESCRIPTION
This is a temporary fix to force an older version of Brunch while an issue is sorted out with compiling with latest brunch.