### PR TITLE
Use new schema endpoint for loading collections

### DIFF
--- a/lib/teamsnap.js
+++ b/lib/teamsnap.js
@@ -3170,7 +3170,8 @@ exports.unlinkItemsFrom = unlinkItemsFrom;
 });
 
 require.register("loadCollections", function(exports, require, module) {
-var Collection, collectionsPromise, promises, types;
+var Collection, collectionsPromise, promises, types,
+  hasProp = {}.hasOwnProperty;
 
 promises = require('./promises');
 
@@ -3183,7 +3184,7 @@ collectionsPromise = null;
 module.exports = function(request, cachedCollections) {
   if (!collectionsPromise || collectionsPromise.getStatus() === 'reject') {
     collectionsPromise = request.get(teamsnap.apiUrl).then(function(xhr) {
-      var collections, key, loads, root, value;
+      var collections, key, loads, ref, ref1, ref2, ref3, root, rootTypeToRels, value;
       collections = {};
       collections.root = root = Collection.fromData(xhr.data);
       if (cachedCollections && cachedCollections.root.version === root.version) {
@@ -3194,16 +3195,35 @@ module.exports = function(request, cachedCollections) {
         }
         return collectionsPromise = promises.resolve(collections);
       } else {
+        rootTypeToRels = {};
         loads = [];
-        types.getTypes().forEach(function(type) {
-          var rel;
-          rel = types.getPluralType(type);
-          if (root.links.has(rel)) {
-            return loads.push(request.get(root.links.href(rel)).then(function(xhr) {
-              return collections[rel] = Collection.fromData(xhr.data);
-            }));
-          }
-        });
+        ref = collections.root.links;
+        for (key in ref) {
+          if (!hasProp.call(ref, key)) continue;
+          value = ref[key];
+          rootTypeToRels[value.href] = key;
+        }
+        if ((ref1 = collections.root) != null ? (ref2 = ref1.links) != null ? (ref3 = ref2.schemas) != null ? ref3.href : void 0 : void 0 : void 0) {
+          loads.push(request.get(collections.root.links.schemas.href).then(function(xhr) {
+            return xhr.data.forEach(function(collection) {
+              var rel;
+              rel = rootTypeToRels[collection.collection.href];
+              if (rel && rel !== "root") {
+                return collections[rel] = Collection.fromData(collection);
+              }
+            });
+          }));
+        } else {
+          types.getTypes().forEach(function(type) {
+            var rel;
+            rel = types.getPluralType(type);
+            if (root.links.has(rel)) {
+              return loads.push(request.get(root.links.href(rel)).then(function(xhr) {
+                return collections[rel] = Collection.fromData(xhr.data);
+              }));
+            }
+          });
+        }
         return promises.when.apply(promises, loads).then(function() {
           return collections;
         });

--- a/src/loadCollections.coffee
+++ b/src/loadCollections.coffee
@@ -12,7 +12,7 @@ module.exports = (request, cachedCollections) ->
     collectionsPromise = request.get(teamsnap.apiUrl).then (xhr) ->
       collections = {}
       collections.root = root = Collection.fromData xhr.data
-      
+
       # Ensure the version hasn't changed, reload it if has
       if cachedCollections and cachedCollections.root.version is root.version
         collections = {}
@@ -20,12 +20,26 @@ module.exports = (request, cachedCollections) ->
           collections[key] = new Collection(value)
         collectionsPromise = promises.resolve collections
       else
+        rootTypeToRels = {}
         loads = []
-        types.getTypes().forEach (type) ->
-          rel = types.getPluralType type
-          if root.links.has rel
-            loads.push request.get(root.links.href rel).then (xhr) ->
-              collections[rel] = Collection.fromData xhr.data
+        for own key, value of collections.root.links
+          rootTypeToRels[value.href] = key
+
+        # try to load collections from schema
+        if collections.root?.links?.schemas?.href
+          loads.push request.get(collections.root.links.schemas.href).then (xhr) ->
+            xhr.data.forEach (collection) ->
+              # have to look up in root to find the link for the rel
+              rel = rootTypeToRels[collection.collection.href]
+              if rel && rel != "root"
+                collections[rel] = Collection.fromData collection
+        else
+          # fallback if schemas endpoint doesn't have an href
+          types.getTypes().forEach (type) ->
+            rel = types.getPluralType type
+            if root.links.has rel
+              loads.push request.get(root.links.href rel).then (xhr) ->
+                collections[rel] = Collection.fromData xhr.data
 
         promises.when(loads...).then ->
           collections


### PR DESCRIPTION
@matthopson Take a look when you get back. I can walk you through the changes. We use the `/schemas` endpoint to load up the collections instead of getting each endpoint manually.