### PR TITLE
Reload members in importMembersFromTeam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # TeamSnap JavaScript SDK CHANGELOG
 
-### May 23, 2016 // Version 1.13.4
+### May 24, 2016 // Version 1.13.4
 - Reloads `members` in `importMembersFromTeam` method in persistence wrapper.
-- Removes reloading of `contacts`, `contactPhoneNumbers` and `memberPhoneNumbers`
-  in `importMembersFromTeam` method in persistence wrapper.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # TeamSnap JavaScript SDK CHANGELOG
 
+### May 23, 2016 // Version 1.13.4
+- Reloads `members` in `importMembersFromTeam` method in persistence wrapper.
+- Removes reloading of `contacts`, `contactPhoneNumbers` and `memberPhoneNumbers`
+  in `importMembersFromTeam` method in persistence wrapper.
+
+---
+
 ### May 5, 2016 // Version 1.13.3
 - Reloads `messages` and `messageData` in `saveBroadcastAlert` method in persistence wrapper.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamsnap.js",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "A JavaScript library for using the TeamSnap API.",
   "author": "Jacob Wright with TeamSnap (http://www.teamsnap.com)",
   "homepage": "https://github.com/teamsnap/teamsnap-javascript-sdk",

--- a/src/persistence.coffee
+++ b/src/persistence.coffee
@@ -195,7 +195,9 @@ modifySDK = (sdk) ->
   # 10. deleteForumTopic needs to delete all related posts
   # 11. memberEmailAddresses need to reload when invite is sent
   # 12. teamFee and memberBalance needs to reload after transaction
-  # 13. members need to be reloaded after importMembersFromTeam
+  # 13. members, contacts, memberEmailAddresses, memberPhoneNumbers,
+  #contactEmailAddresses, contactPhoneNumbers need to be reloaded 
+  #after importMembersFromTeam
   # 14. messages and messageData need to reload after saveBroadcastAlert
 
   # Load related records when a member is created
@@ -708,6 +710,11 @@ modifySDK = (sdk) ->
         memberIds = result.map (member) -> member.id
         promises.when(
           sdk.loadMembers({id: memberIds})
+          sdk.loadContacts({memberId: memberIds})
+          sdk.loadMemberEmailAddresses({memberId: memberIds})
+          sdk.loadMemberPhoneNumbers({memberId: memberIds})
+          sdk.loadContactEmailAddresses({memberId: memberIds})
+          sdk.loadContactEmailAddresses({memberId: memberIds})
         ).then -> result
       ).callback callback
 

--- a/src/persistence.coffee
+++ b/src/persistence.coffee
@@ -195,8 +195,7 @@ modifySDK = (sdk) ->
   # 10. deleteForumTopic needs to delete all related posts
   # 11. memberEmailAddresses need to reload when invite is sent
   # 12. teamFee and memberBalance needs to reload after transaction
-  # 13. memberEmailAddresses and contactEmailAddresses need to be reloaded
-  # after importMembersFromTeam
+  # 13. members need to be reloaded after importMembersFromTeam
   # 14. messages and messageData need to reload after saveBroadcastAlert
 
   # Load related records when a member is created
@@ -708,11 +707,7 @@ modifySDK = (sdk) ->
       .then((result) ->
         memberIds = result.map (member) -> member.id
         promises.when(
-          sdk.loadMemberEmailAddresses({memberId: memberIds})
-          sdk.loadContactEmailAddresses({memberId: memberIds})
-          sdk.loadContacts({memberId: memberIds})
-          sdk.loadMemberPhoneNumbers({memberId: memberIds})
-          sdk.loadContactPhoneNumbers({memberId: memberIds})
+          sdk.loadMembers({id: memberIds})
         ).then -> result
       ).callback callback
 


### PR DESCRIPTION
We have an issue where member information is not displaying until after refresh of the page once `importMemberFromTeam` has been called. This is reloading the specified members to display the information in the UI.

I think we could only reload the member object, not needing to reload email addresses, phone numbers or contacts in the member explicitly.