### PR TITLE
WIP: Remove validation for memberId

### DIFF
--- a/src/collections/assignments.coffee
+++ b/src/collections/assignments.coffee
@@ -21,8 +21,6 @@ exports.saveAssignment = (assignment, callback) ->
   unless @isItem assignment, 'assignment'
     throw new TSArgsError 'teamsnap.saveAssignment',
       "`assignment.type` must be 'assignment'"
-  unless assignment.memberId
-    return @reject 'You must choose a member.', 'memberId', callback
   unless assignment.eventId
     return @reject 'You must choose an event.', 'eventId', callback
   unless assignment.description?.trim()


### PR DESCRIPTION
Removing validation of memberId because in assignments MVP we are allowing an assignment to be created as "Volunteer Needed" with a null memberId.

Versioning and changelog not included in this PR on 6/9/2016. Will make those changes when it's time to merge into master.