### PR TITLE
Load contact emails and phone numbers in persistence when member is saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # TeamSnap JavaScript SDK CHANGELOG
 
+### August 14, 2017 // Version 1.40.0
+- Reloads `contactEmailAddresses` and `contactPhoneNumbers` in `saveMember` in persistence layer.
+
+---
+
 ### August 8, 2017 // Version 1.39.0
 - Adds `registrationLineItems` and `registrationLineItemOptions` collections.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teamsnap.js",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "engines": {
     "node": "^7.0.0",
     "npm": "^3.0.0"

--- a/src/persistence.coffee
+++ b/src/persistence.coffee
@@ -222,6 +222,8 @@ modifySDK = (sdk) ->
       sdk.loadMemberPayments memberId: member.id
       sdk.loadMemberBalances memberId: member.id
       sdk.loadTeamFees teamId: member.teamId
+      sdk.loadContactEmailAddresses teamId: member.teamId
+      sdk.loadContactPhoneNumbers teamId: member.id
     )
 
   # Remove related records when a member is deleted

--- a/src/teamsnap.coffee
+++ b/src/teamsnap.coffee
@@ -3,7 +3,7 @@ promises = require './promises'
 require './errors'
 
 class TeamSnap
-  version: '1.39.1'
+  version: '1.40.0'
   promises: promises
   when: promises.when
   TeamSnap: TeamSnap


### PR DESCRIPTION
- Loads contactEmailAddresses and contactPhoneNumbers when a member is saved. This is needed for when members are saved in combined contact cards feature and the ghost contact is created.